### PR TITLE
Yet another "feature"

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -304,9 +304,6 @@ div.App > div.MoreInformation > p {
 
 div.App > div.MoreInformation > p.Link {
   text-decoration: underline;
-}
-
-div.App > div.MoreInformation > p.Link {
   cursor: pointer;
 }
 

--- a/src/components/information/MoreInformation.tsx
+++ b/src/components/information/MoreInformation.tsx
@@ -13,6 +13,14 @@ const handleClickFlaticon = () => {
   window.open("https://www.flaticon.com/", "true");
 };
 
+const handleClickSourceRKI = () => {
+  window.open("https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4");
+};
+
+const handleClickSourceEsri = () => {
+  window.open("https://experience.arcgis.com/experience/db557289b13c42e4ac33e46314457adc");
+};
+
 
 function MoreInformation() {
   return(
@@ -28,6 +36,11 @@ function MoreInformation() {
         <Typography className="Link Copyright" title="Freepik" onClick={() => handleClickAuthor()}>Freepik</Typography>
         <Typography className="Information Copyright"> from </Typography>
         <Typography className="Link Copyright" title="Flaticon" onClick={() => handleClickFlaticon()}> www.flaticon.com </Typography>
+        <br/>
+        <Typography className="Information Copyright">Current data from </Typography>
+        <Typography className="Link Copyright" title="RKI" onClick={() => handleClickSourceRKI}>RKI</Typography>
+        <Typography className="Information Copyright"> and </Typography>
+        <Typography className="Link Copyright" title="ESRI" onClick={() => handleClickSourceEsri()}>ESRI</Typography>
       </div>
   );
 }

--- a/src/components/information/MoreInformation.tsx
+++ b/src/components/information/MoreInformation.tsx
@@ -38,7 +38,7 @@ function MoreInformation() {
         <Typography className="Link Copyright" title="Flaticon" onClick={() => handleClickFlaticon()}> www.flaticon.com </Typography>
         <br/>
         <Typography className="Information Copyright">Current data from </Typography>
-        <Typography className="Link Copyright" title="RKI" onClick={() => handleClickSourceRKI}>RKI</Typography>
+        <Typography className="Link Copyright" title="RKI" onClick={() => handleClickSourceRKI()}>RKI</Typography>
         <Typography className="Information Copyright"> and </Typography>
         <Typography className="Link Copyright" title="ESRI" onClick={() => handleClickSourceEsri()}>ESRI</Typography>
       </div>

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -40,7 +40,7 @@ function Statistics() {
         <Typography className="HeaderSmall">Aktuelle Zahlen </Typography>
 
         <Typography className="AllInfectionsHeader">Alle Infektionen:</Typography>
-        <Typography 
+        <Typography
             className="AllInfections"
             style={{ color: colorOfInfections}}
         >

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -11,6 +11,7 @@ function Statistics() {
   const [deathsDelta, setDeathsDelta] = useState(0);
   const [allVaccinations, setAllVaccinations] = useState(0);
   const [vaccinationsDelta, setVaccinationsDelta] = useState(0);
+  const [sevenDayIncident, setSevenDayIncident] = useState(0);
 
   Api.makeApiRequestToRKIData(UrlConfig.urlAllInfections).then(result => setAllInfections(result));
   Api.makeApiRequestToRKIData(UrlConfig.urlInfectionsDelta).then(result => setInfectionsDelta(result));
@@ -18,7 +19,20 @@ function Statistics() {
   Api.makeApiRequestToRKIData(UrlConfig.urlDeathsDelta).then(result => setDeathsDelta(result));
   Api.makeApiRequestToRKIData(UrlConfig.urlAllVaccinations).then(result => setAllVaccinations(result));
   Api.makeApiRequestToRKIData(UrlConfig.urlAllVaccinationsDelta).then(result => setVaccinationsDelta(result));
+  Api.makeIncidentRequest(UrlConfig.urlIncident).then(result => setSevenDayIncident(result));
+
   const colorOfElement = infectionsDelta > 10000 ? "#c42929" : "black";
+  
+  let colorOfInfections = "black";
+  if(sevenDayIncident > 100){
+    colorOfInfections =  "red" //"#c42929"
+  }
+  else if(sevenDayIncident < 50){
+    colorOfInfections =  "green" //"#43c429"
+  }
+  else{
+    colorOfInfections = "yellow" //"#e0de4c"
+  }
 
   return (
       <div className="Statistics" id="Statistics">
@@ -26,7 +40,12 @@ function Statistics() {
         <Typography className="HeaderSmall">Aktuelle Zahlen </Typography>
 
         <Typography className="AllInfectionsHeader">Alle Infektionen:</Typography>
-        <Typography className="AllInfections">{Formatter.formatNumber(allInfections)}</Typography>
+        <Typography 
+            className="AllInfections"
+            style={{ color: colorOfInfections}}
+        >
+          {Formatter.formatNumber(allInfections)}
+        </Typography>
         <Typography className="AllInfectionsDeltaHeader">zum Vortag:</Typography>
         <Typography
             className="AllInfectionsDelta"

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -22,16 +22,17 @@ function Statistics() {
   Api.makeIncidentRequest(UrlConfig.urlIncident).then(result => setSevenDayIncident(result));
 
   const colorOfElement = infectionsDelta > 10000 ? "#c42929" : "black";
+  let information = "Derzeit werden die Infektionszahlen anhand des 7-Tage-Inzidenz-Wertes eingefärbt.\nAlles über 100 wird rot eingefärbt.\nAlles zwischen 50 und 100 wird gelb eingefärbt.\nAlles unter 50 wird grün eingefärbt.\n\nDerzeitiger Wert: "+sevenDayIncident;
   
   let colorOfInfections = "black";
   if(sevenDayIncident > 100){
-    colorOfInfections =  "red" //"#c42929"
+    colorOfInfections =  "#c42929"
   }
   else if(sevenDayIncident < 50){
-    colorOfInfections =  "green" //"#43c429"
+    colorOfInfections =  "#43c429"
   }
   else{
-    colorOfInfections = "yellow" //"#e0de4c"
+    colorOfInfections = "#e0de4c"
   }
 
   return (
@@ -42,6 +43,7 @@ function Statistics() {
         <Typography className="AllInfectionsHeader">Alle Infektionen:</Typography>
         <Typography
             className="AllInfections"
+            title={information}
             style={{ color: colorOfInfections}}
         >
           {Formatter.formatNumber(allInfections)}

--- a/src/config/Urls.tsx
+++ b/src/config/Urls.tsx
@@ -4,6 +4,7 @@ const urlAllDeaths = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/
 const urlDeathsDelta = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0/query?f=json&where=NeuerTodesfall%20IN(1%2C%20-1)&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&outStatistics=%5B%7B%22statisticType%22%3A%22sum%22%2C%22onStatisticField%22%3A%22AnzahlTodesfall%22%2C%22outStatisticFieldName%22%3A%22value%22%7D%5D&resultType=standard&cacheHint=true"
 const urlAllVaccinations = "https://services.arcgis.com/OLiydejKCZTGhvWg/arcgis/rest/services/BL_mit_Impfdaten_join/FeatureServer/0/query?f=json&where=1%3D1&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&outStatistics=%5B%7B%22statisticType%22%3A%22sum%22%2C%22onStatisticField%22%3A%22Impfungen_kumulativ%22%2C%22outStatisticFieldName%22%3A%22value%22%7D%5D&resultType=standard&cacheHint=true"
 const urlAllVaccinationsDelta = "https://services.arcgis.com/OLiydejKCZTGhvWg/arcgis/rest/services/BL_mit_Impfdaten_join/FeatureServer/0/query?f=json&where=1%3D1&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&outStatistics=%5B%7B%22statisticType%22%3A%22sum%22%2C%22onStatisticField%22%3A%22Differenz_zum_Vortag%22%2C%22outStatisticFieldName%22%3A%22value%22%7D%5D&resultType=standard&cacheHint=true"
+const urlIncident = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19_Landkreise_Table_Demo_18b5f806160a4aa686ca65819fbe4462/FeatureServer/0/query?f=json&where=1%3D1&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&orderByFields=RS%20asc&resultOffset=0&resultRecordCount=1&resultType=standard&cacheHint=true"
 
 const UrlConfig = {
   urlAllInfections,
@@ -11,7 +12,8 @@ const UrlConfig = {
   urlAllDeaths,
   urlDeathsDelta,
   urlAllVaccinations,
-  urlAllVaccinationsDelta
+  urlAllVaccinationsDelta,
+  urlIncident
 }
 
 export default UrlConfig;

--- a/src/utils/api/Api.tsx
+++ b/src/utils/api/Api.tsx
@@ -7,7 +7,7 @@ const makeApiRequestToRKIData = async (url: string) => {
 
 const makeIncidentRequest = async (url: string) => {
   const response = await (await fetch(url)).json();
-  const data: number = response.features[0].attributes.cases7_per_100k.toFixed(1); // this should work
+  const data: number = response.features[0].attributes.cases7_per_100k; // this should work
 
   return data;
 }

--- a/src/utils/api/Api.tsx
+++ b/src/utils/api/Api.tsx
@@ -5,8 +5,16 @@ const makeApiRequestToRKIData = async (url: string) => {
   return data;
 };
 
+const makeIncidentRequest = async (url: string) => {
+  const response = await (await fetch(url)).json();
+  const data: number = response.features[0].attributes.cases7_per_100k.toFixed(1); // this should work
+
+  return data;
+}
+
 const Api = {
   makeApiRequestToRKIData,
+  makeIncidentRequest
 }
 
 export default Api;


### PR DESCRIPTION
Introducing the "7-Day-Incident" number.
Germany consideres the corona virus under control if the 7 day incident number is below 50.

Currently its around 123,5.
Welp that sucks.

However I colored the total infections based on this number.
If its above 100 then the total infections are colored red. (Danger)
If its between 50 and 100 the total infections will be colored yellow (Warning)
If its below 50 the total infections will be colored green (Under Control)

This could lead the user to believe that we "like" or "dislike" the current numbers (if you know what I mean?)
We could solve this by adding a "status" text.

Also I've added links to the sources we are using.