### PR TITLE
Addressing the firefox issue

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,8 +22,7 @@ p {
 
 div.App {
   width: 100vw;
-  height: 100vh;
-
+  height: 100%;
   display: grid;
   grid-template-areas:
           ". . expandable-icon"
@@ -70,7 +69,7 @@ div.App > div.ExpandablePage {
   position: absolute;
   z-index: 1;
 
-  margin-left: 100%; 
+  margin-left: 100%;
   
   /*
   This is a true fix for the Firefox issue.
@@ -79,7 +78,7 @@ div.App > div.ExpandablePage {
 
   Dirty fix would be to up the margin-left value.
   This increases the time it takes to display that page tho
-  */  
+  */
   left: 0;
 
   transition: margin-left ease-in-out 1s;

--- a/src/App.css
+++ b/src/App.css
@@ -70,7 +70,18 @@ div.App > div.ExpandablePage {
   position: absolute;
   z-index: 1;
 
-  margin-left: 300%; /* It seems that margin-left: 100% fails for firefox.  */
+  margin-left: 100%; 
+  
+  /*
+  This is a true fix for the Firefox issue.
+  Apparently the ExpandablePage ID is defaulting to be centered on the page.
+  Adding left: 0; will start to position the page on its correct location.
+
+  Dirty fix would be to up the margin-left value.
+  This increases the time it takes to display that page tho
+  */  
+  left: 0;
+
   transition: margin-left ease-in-out 1s;
 
   display: grid;

--- a/src/App.css
+++ b/src/App.css
@@ -70,7 +70,7 @@ div.App > div.ExpandablePage {
   position: absolute;
   z-index: 1;
 
-  margin-left: 100%;
+  margin-left: 300%; /* It seems that margin-left: 100% fails for firefox.  */
   transition: margin-left ease-in-out 1s;
 
   display: grid;


### PR DESCRIPTION
So when you have visited the page on firefox you will be greeted like this.

![firefox css issue](https://cdn.discordapp.com/attachments/768377960046002210/803563813449236490/unknown.png)

Quick inspection showed, that `margin-left: 100%` did not correctly show on firefox.
I upped the value to 300% to pFix this issue until this is further investigated.